### PR TITLE
Added refresh button for new ondemand patients added while provider i…

### DIFF
--- a/app/components/Patient/PaymentForm/PaymentForm.tsx
+++ b/app/components/Patient/PaymentForm/PaymentForm.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { Uris } from '../../../services/constants';
+import datastoreService from '../../../services/datastoreService';
 import { US_STATES, ZIP_REGEX } from '../../../utils';
 import useSyncContext from '../../Base/SyncProvider/useSyncContext/useSyncContext';
 import { Button } from '../../Button';
@@ -11,13 +12,10 @@ import { Select } from '../../Select';
 export interface PaymentFormProps {}
 
 export const PaymentForm = ({}: PaymentFormProps) => {
-  // const { connect: syncConnect } = useSyncContext();
   const router = useRouter();
 
-  const onSubmit = (data) => {
+  const onSubmit = async (data) => {
     console.log(data);
-    // validate payment here
-    // if success, go to next page, else show payment failed try again
     router.push(`/patient/on-demand/payment/received`);
   }
 

--- a/app/components/Provider/PatientQueueCard/PatientQueueCard.tsx
+++ b/app/components/Provider/PatientQueueCard/PatientQueueCard.tsx
@@ -2,11 +2,15 @@ import { Card } from '../../Card';
 import { CardHeading } from '../CardHeading';
 import {TelehealthVisit} from "../../../types";
 import { PatientVisitCard } from './PatientVisitCard';
+import { Button } from '../../Button/Button';
+import { useCallback } from 'react';
 
 export interface PatientQueueCardProps {
   className?: string;
   visitQueue: TelehealthVisit[];
   onDemandQueue: TelehealthVisit[];
+  isNewVisit: boolean;
+  setIsNewVisit: (isVisit:boolean) => void;
 }
 
 function calculateWaitTime(visitStartTimeLTZ) {
@@ -19,10 +23,22 @@ function calculateWaitTime(visitStartTimeLTZ) {
   return (diffSeconds > 0 ? 'Waiting ': 'Starting ') + hhmmdd;
 }
 
-export const PatientQueueCard = ({ className, onDemandQueue, visitQueue }: PatientQueueCardProps) => {
+export const PatientQueueCard = ({ className, onDemandQueue, visitQueue, isNewVisit, setIsNewVisit }: PatientQueueCardProps) => {
+  const refreshQueueCard = useCallback(() => {
+      setIsNewVisit(false);
+      window.location.reload();
+    }, [setIsNewVisit]
+  );
+
   return (
     <Card className={className}>
-      <CardHeading>Patient Queue</CardHeading>
+      <CardHeading>
+        Patient Queue {"  "}{isNewVisit && 
+        <Button onClick={refreshQueueCard}>
+          Refresh
+        </Button>
+      }
+      </CardHeading>
       <div className="px-1 py-2 grid grid-cols-2 gap-4 font-bold text-xs">
         <div>Patient</div>
         <div>Reason For Visit:</div>


### PR DESCRIPTION
- Added a refresh button when provider is currently viewing the dashboard.
  - Appears after receiving pub/sub message
  - disappears after provider clicks the button
- When provider not in dashboard, the appointment is added regardless via `datastoreService.addAppointment(token, appointment)`