### PR TITLE
Connected the end call flow and added modal to explicitly end video call

### DIFF
--- a/app/components/EndCallModal/EndCallModal.tsx
+++ b/app/components/EndCallModal/EndCallModal.tsx
@@ -1,0 +1,37 @@
+import router, { useRouter } from "next/router";
+import useVideoContext from "../Base/VideoProvider/useVideoContext/useVideoContext";
+import { Button } from "../Button";
+import { Modal } from "../Modal"
+
+export interface EndCallModalProps {
+  close: () => void;
+  isVisible: boolean;
+  isProvider: boolean;
+}
+
+export const EndCallModal = ({ close, isVisible, isProvider = false }: EndCallModalProps) => {
+  const { room } = useVideoContext();
+  const router = useRouter();
+
+  function endCall() {
+    console.log("EndedCall");
+    close();
+    room.disconnect();
+    isProvider ? router.push('/provider/visit-survey/') : router.push('/patient/visit-survey/');
+  }
+
+  return (
+    <Modal backdropClick={close} isVisible={isVisible}>
+      <div className="mb-3 border-b border-border-primary">
+        <h3 className="my-3 px-5">{isProvider ? "End Call for all participants?" : "End Call?"}</h3>
+      </div>
+      <div className="flex mb-5 mx-5 items-center justify-center">
+        <div className="mx-2">
+          <Button onClick={endCall}>
+            {isProvider ? "End Session" : "Leave Call"}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/app/components/EndCallModal/index.tsx
+++ b/app/components/EndCallModal/index.tsx
@@ -1,0 +1,1 @@
+export * from './EndCallModal';

--- a/app/components/Provider/NextPatientCard/NextPatientCard.tsx
+++ b/app/components/Provider/NextPatientCard/NextPatientCard.tsx
@@ -17,8 +17,8 @@ export interface NextPatientCardProps {
 
 export const NextPatientCard = ({ className, visitNext }: NextPatientCardProps) => {
   const router = useRouter();
-    const [ visitWaitTime, setVisitWaitTime ] = useState<string>();
-    const [ visitNeedTranslator, setVisitNeedTranslator ] = useState<string>();
+  const [ visitWaitTime, setVisitWaitTime ] = useState<string>();
+  const [ visitNeedTranslator, setVisitNeedTranslator ] = useState<string>();
 
   const Field = ({ label, value }) => (
     <li className="my-4 text-xs">

--- a/app/components/Provider/VideoConsultation/VideoConsultation.tsx
+++ b/app/components/Provider/VideoConsultation/VideoConsultation.tsx
@@ -17,6 +17,7 @@ import useLocalVideoToggle from '../../Base/VideoProvider/useLocalVideoToggle/us
 import { roomService } from '../../../services/roomService';
 import useSelectedParticipant from '../../Base/VideoProvider/useSelectedParticipant/useSelectedParticipant';
 import { RemoteParticipant } from 'twilio-video';
+import { EndCallModal } from '../../EndCallModal';
 
 export interface VideoConsultationProps {}
 
@@ -26,6 +27,7 @@ export const VideoConsultation = ({}: VideoConsultationProps) => {
   const [isAudioEnabled, toggleAudioEnabled] = useLocalAudioToggle();
   const [isVideoEnabled, toggleVideoEnabled] = useLocalVideoToggle();
   const [inviteModalRef, setInviteModalRef] = useState(null);
+  const [endCallModalVisible, setEndCallModalVisible] = useState(false);
   const [settingsModalRef, setSettingsModalRef] = useState(null);
   const [connectionIssueModalVisible, setConnectionIssueModalVisible] = useState(false);
   const participants = useParticipants();
@@ -41,6 +43,10 @@ export const VideoConsultation = ({}: VideoConsultationProps) => {
     providerParticipant: null,
     visitorParticipant: null,
   });
+
+  function toggleEndCallModal() {
+    setEndCallModalVisible(!endCallModalVisible);
+  }
 
   useEffect(() => {
     if (room) {
@@ -120,6 +126,7 @@ export const VideoConsultation = ({}: VideoConsultationProps) => {
             setSettingsModalRef(settingsModalRef ? null : event?.target)
           }
           toggleVideo={toggleVideoEnabled}
+          toggleEndCallModal={toggleEndCallModal}
         />
         <div className="absolute bottom-6">
           <PoweredByTwilio inverted />
@@ -151,6 +158,11 @@ export const VideoConsultation = ({}: VideoConsultationProps) => {
         isRecording={isRecording}
         isVisible={!!settingsModalRef}
         toggleRecording={toggleRecordingCb}
+      />
+      <EndCallModal
+        close={toggleEndCallModal}
+        isVisible={endCallModalVisible}
+        isProvider={true}
       />
     </div>
   );

--- a/app/components/VideoControls/VideoControls.tsx
+++ b/app/components/VideoControls/VideoControls.tsx
@@ -15,6 +15,7 @@ export interface VideoControlsProps {
   toggleScreenShare?: ControlClickEvent;
   toggleSettings?: ControlClickEvent;
   toggleVideo?: ControlClickEvent;
+  toggleEndCallModal?: ControlClickEvent;
 }
 
 export const VideoControls = ({
@@ -26,6 +27,7 @@ export const VideoControls = ({
   toggleScreenShare,
   toggleSettings,
   toggleVideo,
+  toggleEndCallModal
 }: VideoControlsProps) => {
   const buttonClasses = 'mx-1.5';
   const addPersonRef = useRef();
@@ -93,12 +95,15 @@ export const VideoControls = ({
           onClick={toggleSettings}
         />
       )}
-      <Button
-        className={buttonClasses}
-        as="a"
-        href="/patient/video/disconnected"
-        icon="call_end"
-      />
+      {toggleEndCallModal && (
+        <Button
+          className={buttonClasses}
+          // as="a"
+          // href="/patient/video/disconnected"
+          icon="call_end"
+          onClick={toggleEndCallModal}
+        />
+      )}
     </div>
   );
 };

--- a/app/pages/provider/dashboard/index.tsx
+++ b/app/pages/provider/dashboard/index.tsx
@@ -33,7 +33,6 @@ const DashboardPage: TwilioPage = () => {
   const fetchVisits = useCallback(async () => {
     datastoreService.fetchAllTelehealthVisits(user)
       .then(async allVisits => {
-        console.log(allVisits);
         const onDemandVisits = allVisits.filter(visit => visit.ehrAppointment.type === 'WALKIN');
         const regularVisits = allVisits.filter(visit => visit.ehrAppointment.type !== 'WALKIN');
         setOnDemandQueue(onDemandVisits);

--- a/app/pages/provider/visit-survey/thank-you.tsx
+++ b/app/pages/provider/visit-survey/thank-you.tsx
@@ -1,15 +1,30 @@
+import { useRouter } from 'next/router';
 import React from 'react';
 import { Alert } from '../../../components/Alert';
+import { Button } from '../../../components/Button';
 import { CardLayout } from '../../../components/Provider';
 
 const VisitSurveyThankYouPage = () => {
+  const router = useRouter();
+  const goToDashBoard = () => {
+    router.push('/provider/dashboard/');
+  }
   return (
     <CardLayout>
       <Alert
         title={`Thanks for your feedback`}
         titleAfterIcon
         icon={<img src="/icons/check-circle.svg" height={75} width={75} />}
-        content={<p className="">You can close this window now.</p>}
+        content={
+          <p className="">You can close this window now or<br/>
+            <Button
+              className="mt-3" 
+              onClick={goToDashBoard}
+            >
+              Go to Dashboard
+            </Button> 
+          </p>
+        }
       />
     </CardLayout>
   );


### PR DESCRIPTION
Changes:
- End call modal to ensujre intent
- After survey Provider can rejoin the dashboard page again
- Provider leaving the video room disconnects the patient and sends them the post visit survey
- If Provider is disconnected too long, then the patient should be automatically sent to the post visit survey